### PR TITLE
chart: add service monitor + metrics.

### DIFF
--- a/charts/surveyjs-validator/templates/deployment.yaml
+++ b/charts/surveyjs-validator/templates/deployment.yaml
@@ -40,6 +40,9 @@ spec:
             - name: http
               containerPort: 3000
               protocol: TCP
+            - name: metrics
+              containerPort: 9464
+              protocol: TCP
           livenessProbe:
             {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:

--- a/charts/surveyjs-validator/templates/service.yaml
+++ b/charts/surveyjs-validator/templates/service.yaml
@@ -11,5 +11,9 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+    - port: {{ .Values.service.metricsPort }}
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
   selector:
     {{- include "surveyjs-validator.selectorLabels" . | nindent 4 }}

--- a/charts/surveyjs-validator/templates/servicemonitor.yaml
+++ b/charts/surveyjs-validator/templates/servicemonitor.yaml
@@ -1,0 +1,18 @@
+{{ if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "surveyjs-validator.fullname" . }}
+  labels:
+    {{- include "surveyjs-validator.labels" . | nindent 4 }}
+spec:
+  selector:
+    {{- include "surveyjs-validator.selectorLabels" . | nindent 4 }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  endpoints:
+    - path: /metrics
+    - port: metrics
+      interval: 10s
+{{ end }}

--- a/charts/surveyjs-validator/values.yaml
+++ b/charts/surveyjs-validator/values.yaml
@@ -25,6 +25,10 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+# prometheus metrics
+serviceMonitor:
+  enabled: false
+
 podAnnotations: {}
 podLabels: {}
 
@@ -42,6 +46,7 @@ securityContext: {}
 service:
   type: ClusterIP
   port: 80
+  metricsPort: 9464
 
 ingress:
   enabled: false
@@ -60,11 +65,11 @@ ingress:
 # surveyjs-validator will only use 1 CPU core max
 resources: {}
   # limits:
-  #   cpu: 100m
+  #   cpu: 1000m
   #   memory: 128Mi
   # requests:
   #   cpu: 100m
-  #   memory: 128Mi
+  #   memory: 64Mi
 
 livenessProbe:
   httpGet:


### PR DESCRIPTION
Adds an optional service monitor and configures the service metrics port.

Also adjusts the hint for default memory / cpu usage based on the actual usage.